### PR TITLE
MAT-7026: flow.qrCode is missing in Charge response object in java sdk

### DIFF
--- a/src/main/java/com/shift4/request/ThreeDSecureRequest.java
+++ b/src/main/java/com/shift4/request/ThreeDSecureRequest.java
@@ -141,7 +141,7 @@ public class ThreeDSecureRequest {
 			return this;
 		}
 
-		enum Status {
+		public enum Status {
 			Y, N, A, U, R, E
 		}
 	}

--- a/src/main/java/com/shift4/response/ChargeFlow.java
+++ b/src/main/java/com/shift4/response/ChargeFlow.java
@@ -7,6 +7,7 @@ public class ChargeFlow {
 	private ChargeFlowActionType nextAction;
 	private Redirect redirect;
 	private String returnUrl;
+	private QrCode qrCode;
 
 	public ChargeFlowActionType getNextAction() {
 		return nextAction;
@@ -18,6 +19,10 @@ public class ChargeFlow {
 
 	public String getReturnUrl() {
 		return returnUrl;
+	}
+
+	public QrCode getQrCode() {
+		return qrCode;
 	}
 
 	public ChargeFlow nextAction(ChargeFlowActionType nextAction) {
@@ -35,6 +40,11 @@ public class ChargeFlow {
 		return this;
 	}
 
+	public ChargeFlow qrCode(QrCode qrCode) {
+		this.qrCode = qrCode;
+		return this;
+	}
+
 	public static class Redirect {
 		private String redirectUrl;
 
@@ -44,6 +54,19 @@ public class ChargeFlow {
 
 		public Redirect redirectUrl(String redirectUrl) {
 			this.redirectUrl = redirectUrl;
+			return this;
+		}
+	}
+
+	public static class QrCode {
+		private String imgSrc;
+
+		public String getImgSrc() {
+			return imgSrc;
+		}
+
+		public QrCode imgSrc(String imgSrc) {
+			this.imgSrc = imgSrc;
 			return this;
 		}
 	}


### PR DESCRIPTION
1. Add `qrCode` back for `ChargeFlow`
2. Fix the visibility for `ThreeDSecureRequest.External.Status`